### PR TITLE
bump sdk version, rename paginationMessageCid to cursor

### DIFF
--- a/.github/workflows/integrity-checks.yml
+++ b/.github/workflows/integrity-checks.yml
@@ -18,14 +18,17 @@ jobs:
       run:
         shell: bash
     runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        node: [18, 20]
     steps:
       - name: Checkout source
-        uses: actions/checkout@8e5e7e5ab8b370d6c329ec480221332ada57f0ab # v3.5.2
+        uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
 
       - name: Set up Node.js
-        uses: actions/setup-node@64ed1c7eab4cce3362f8c340dee64e5eaeef8f7c # v3.6.0
+        uses: actions/setup-node@8f152de45cc393bb48ce5d89d36b731f54556e65 # v4.0.0
         with:
-          node-version: 20
+          node-version: ${{ matrix.node }}
 
       - name: Install dependencies
         run: npm ci
@@ -35,7 +38,7 @@ jobs:
 
       - name: Run audit checks
         run: npm audit
-      
+
       - name: Test build
         run: npm run build
 
@@ -44,12 +47,11 @@ jobs:
           sudo apt update
           sudo apt install sqlite3
           ./scripts/start-databases
-      
+
       - name: Run tests
         run: npm run test-coverage
 
       - name: Upload coverage reports to Codecov
-        uses: codecov/codecov-action@v3
+        uses: codecov/codecov-action@eaaf4bedf32dbdc6b720b63067d99c4d77d6047d # v3.1.4
         env:
           CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
-      

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -9,7 +9,7 @@
 # The format is described: https://github.blog/2017-07-06-introducing-code-owners/
 
 # These owners will be the default owners for everything in the repo.
-* @amika-sq @mistermoe @adam4leos
+* @amika-sq @mistermoe @lirancohen @thehenrytsai
 
 
 # -----------------------------------------------

--- a/README.md
+++ b/README.md
@@ -112,7 +112,8 @@ const dwn = await Dwn.create({ messageStore, dataStore, eventLog });
 
 ## Prerequisites
 ### `node` and `npm`
-This project is using `node v20.3.0` and `npm v9.6.7`. You can verify your `node` and `npm` installation via the terminal:
+This project is developed and tested with [Node.js](https://nodejs.org/en/about/previous-releases)
+`v18` and `v20` and NPM `v9`. You can verify your `node` and `npm` installation via the terminal:
 
 ```
 $ node --version

--- a/package-lock.json
+++ b/package-lock.json
@@ -23,7 +23,7 @@
         "@types/node": "20.3.1",
         "@types/pg": "8.10.2",
         "@types/pg-cursor": "2.7.0",
-        "@types/readable-stream": "2.3.15",
+        "@types/readable-stream": "4.0.6",
         "@types/supertest": "2.0.12",
         "@typescript-eslint/eslint-plugin": "5.59.11",
         "@typescript-eslint/parser": "5.59.11",
@@ -40,6 +40,9 @@
         "rimraf": "5.0.1",
         "ts-sinon": "2.0.2",
         "typescript": "5.0.4"
+      },
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/@aashutoshrathi/word-wrap": {
@@ -1154,9 +1157,9 @@
       "dev": true
     },
     "node_modules/@types/readable-stream": {
-      "version": "2.3.15",
-      "resolved": "https://registry.npmjs.org/@types/readable-stream/-/readable-stream-2.3.15.tgz",
-      "integrity": "sha512-oM5JSKQCcICF1wvGgmecmHldZ48OZamtMxcGGVICOJA8o8cahXC1zEVAif8iwoc5j8etxFaRFnf095+CDsuoFQ==",
+      "version": "4.0.6",
+      "resolved": "https://registry.npmjs.org/@types/readable-stream/-/readable-stream-4.0.6.tgz",
+      "integrity": "sha512-awa7+N1SSD9xz8ZvEUSO3/N3itc2PMH6Sca11HiX55TVsWiMaIgmbM76lN+2eZOrCQPiFqj0GmgsfsNtNGWoUw==",
       "dev": true,
       "dependencies": {
         "@types/node": "*",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@tbd54566975/dwn-sql-store",
-  "version": "0.2.2",
+  "version": "0.2.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@tbd54566975/dwn-sql-store",
-      "version": "0.2.2",
+      "version": "0.2.3",
       "license": "Apache-2.0",
       "dependencies": {
         "@ipld/dag-cbor": "^9.0.5",

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "license": "Apache-2.0",
       "dependencies": {
         "@ipld/dag-cbor": "^9.0.5",
-        "@tbd54566975/dwn-sdk-js": "0.2.6",
+        "@tbd54566975/dwn-sdk-js": "0.2.7",
         "kysely": "0.26.3",
         "multiformats": "12.0.1",
         "readable-stream": "4.4.2"
@@ -892,9 +892,9 @@
       "dev": true
     },
     "node_modules/@tbd54566975/dwn-sdk-js": {
-      "version": "0.2.6",
-      "resolved": "https://registry.npmjs.org/@tbd54566975/dwn-sdk-js/-/dwn-sdk-js-0.2.6.tgz",
-      "integrity": "sha512-q9HjMhW9KyUD94XVjuO4N+tkeZaOsgtRINIioMKucuZZTCb8Z2lilUleZqc7LiVePCMzlqdRBVeJpMKbnAGj8Q==",
+      "version": "0.2.7",
+      "resolved": "https://registry.npmjs.org/@tbd54566975/dwn-sdk-js/-/dwn-sdk-js-0.2.7.tgz",
+      "integrity": "sha512-p7W7di+bf7X3mFu7HURYCr+WV4HJOu9SntqSjMf6J2i7PveOpwEfxQ16aEdTtPvg1v6i5GfMbYYmwuKDlRuBwA==",
       "dependencies": {
         "@ipld/dag-cbor": "9.0.3",
         "@js-temporal/polyfill": "0.4.4",
@@ -916,7 +916,7 @@
         "ms": "2.1.3",
         "multiformats": "11.0.2",
         "randombytes": "2.1.0",
-        "readable-stream": "4.4.0",
+        "readable-stream": "4.4.2",
         "ulidx": "2.1.0",
         "uuid": "8.3.2",
         "varint": "6.0.0"
@@ -962,20 +962,6 @@
       "engines": {
         "node": ">=16.0.0",
         "npm": ">=7.0.0"
-      }
-    },
-    "node_modules/@tbd54566975/dwn-sdk-js/node_modules/readable-stream": {
-      "version": "4.4.0",
-      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-4.4.0.tgz",
-      "integrity": "sha512-kDMOq0qLtxV9f/SQv522h8cxZBqNZXuXNyjyezmfAAuribMyVXziljpQ/uQhfE1XLg2/TLTW2DsnoE4VAi/krg==",
-      "dependencies": {
-        "abort-controller": "^3.0.0",
-        "buffer": "^6.0.3",
-        "events": "^3.3.0",
-        "process": "^0.11.10"
-      },
-      "engines": {
-        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
       }
     },
     "node_modules/@types/better-sqlite3": {

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
   "react-native": "./dist/esm/src/main.js",
   "dependencies": {
     "@ipld/dag-cbor": "^9.0.5",
-    "@tbd54566975/dwn-sdk-js": "0.2.6",
+    "@tbd54566975/dwn-sdk-js": "0.2.7",
     "kysely": "0.26.3",
     "multiformats": "12.0.1",
     "readable-stream": "4.4.2"

--- a/package.json
+++ b/package.json
@@ -76,10 +76,6 @@
       "url": "https://github.com/mistermoe"
     },
     {
-      "name": "Adam Leos",
-      "url": "https://github.com/adam4leos"
-    },
-    {
       "name": "Liran Cohen",
       "url": "https://github.com/lirancohen"
     }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tbd54566975/dwn-sql-store",
-  "version": "0.2.2",
+  "version": "0.2.3",
   "description": "SQL backed implementations of DWN MessageStore, DataStore, and EventLog",
   "type": "module",
   "license": "Apache-2.0",

--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
     "@types/node": "20.3.1",
     "@types/pg": "8.10.2",
     "@types/pg-cursor": "2.7.0",
-    "@types/readable-stream": "2.3.15",
+    "@types/readable-stream": "4.0.6",
     "@types/supertest": "2.0.12",
     "@typescript-eslint/eslint-plugin": "5.59.11",
     "@typescript-eslint/parser": "5.59.11",

--- a/package.json
+++ b/package.json
@@ -66,6 +66,9 @@
     "dist",
     "src"
   ],
+  "engines": {
+    "node": ">=18"
+  },
   "contributors": [
     {
       "name": "Adam Mika",

--- a/tests/test-suite.spec.ts
+++ b/tests/test-suite.spec.ts
@@ -4,6 +4,11 @@ import { MessageStoreSql } from '../src/message-store-sql.js';
 import { DataStoreSql } from '../src/data-store-sql.js';
 import { EventLogSql } from '../src/event-log-sql.js';
 
+// Remove when we Node.js v18 is no longer supported by this project.
+// Node.js v18 maintenance begins 2023-10-18 and is EoL 2025-04-30: https://github.com/nodejs/release#release-schedule
+import { webcrypto } from 'node:crypto';
+if (!globalThis.crypto) globalThis.crypto = webcrypto;
+
 describe('SQL Store Test Suite', () => {
   describe('MysqlDialect Support', () => {
     TestSuite.runStoreDependentTests({


### PR DESCRIPTION
This PR will:
- Bump DWN SDK version from `v0.2.6` to `v0.2.7`
- Rename `paginationMessageCid` to `cursor` for the `MessageStore` interface.
- Bump @types/readable-stream from `v2.3.15` to `v.4.0.6` to match DWN SDK.
- Add CI workflow testing for Node.js v18 since DWN SDK currently supports both v18 and v20.
- Update `CODEOWNERS`.