### PR TITLE
Bump `dwn-sdk-js` to `v0.2.9`

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "license": "Apache-2.0",
       "dependencies": {
         "@ipld/dag-cbor": "^9.0.5",
-        "@tbd54566975/dwn-sdk-js": "0.2.8",
+        "@tbd54566975/dwn-sdk-js": "0.2.9",
         "kysely": "0.26.3",
         "multiformats": "12.0.1",
         "readable-stream": "4.4.2"
@@ -895,9 +895,9 @@
       "dev": true
     },
     "node_modules/@tbd54566975/dwn-sdk-js": {
-      "version": "0.2.8",
-      "resolved": "https://registry.npmjs.org/@tbd54566975/dwn-sdk-js/-/dwn-sdk-js-0.2.8.tgz",
-      "integrity": "sha512-oiKk+ekAQO94bUkt6yk+xkDY8uCGmNC+rKaYQLhAoTrhYrczeRSuDT04F5/vPBT5K6NfAoRcQsIyBmvgRCUvgA==",
+      "version": "0.2.9",
+      "resolved": "https://registry.npmjs.org/@tbd54566975/dwn-sdk-js/-/dwn-sdk-js-0.2.9.tgz",
+      "integrity": "sha512-p9wv0GrNq0BgUMvlS54osLKAZE/WhTV89Oh0nvGUk9NH5iwvswlbG4aygw4vDqdVo7XruzfGienW0X/eNWZL0g==",
       "dependencies": {
         "@ipld/dag-cbor": "9.0.3",
         "@js-temporal/polyfill": "0.4.4",
@@ -908,7 +908,6 @@
         "blockstore-core": "4.2.0",
         "cross-fetch": "4.0.0",
         "eciesjs": "0.4.5",
-        "flat": "5.0.2",
         "interface-blockstore": "5.2.3",
         "interface-store": "5.1.2",
         "ipfs-unixfs-exporter": "13.1.5",
@@ -2578,6 +2577,7 @@
       "version": "5.0.2",
       "resolved": "https://registry.npmjs.org/flat/-/flat-5.0.2.tgz",
       "integrity": "sha512-b6suED+5/3rTpUBdG1gupIl8MPFCAMA0QXwmljLhvCUKcUvdE4gWky9zpuGCcXHOsz4J9wPGNWq6OKpmIzz3hQ==",
+      "dev": true,
       "bin": {
         "flat": "cli.js"
       }

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
   "react-native": "./dist/esm/src/main.js",
   "dependencies": {
     "@ipld/dag-cbor": "^9.0.5",
-    "@tbd54566975/dwn-sdk-js": "0.2.8",
+    "@tbd54566975/dwn-sdk-js": "0.2.9",
     "kysely": "0.26.3",
     "multiformats": "12.0.1",
     "readable-stream": "4.4.2"

--- a/src/database.ts
+++ b/src/database.ts
@@ -1,9 +1,40 @@
 import type { Generated } from 'kysely';
 
 export interface EventLogTable {
-  id: Generated<number>;
+  watermark: Generated<number>;
   tenant: string;
   messageCid: string;
+
+  // "indexes" start
+  interface: string | null;
+  method: string | null;
+  schema: string | null;
+  dataCid: string | null;
+  dataSize: number | null;
+  dateCreated: string | null;
+  messageTimestamp: string | null;
+  dataFormat: string | null;
+  isLatestBaseState: string | null;
+  published: string | null;
+  author: string | null;
+  recordId: string | null;
+  entryId: string | null;
+  datePublished: string | null;
+  latest: string | null;
+  protocol: string | null;
+  dateExpires: string | null;
+  description: string | null;
+  grantedTo: string | null;
+  grantedBy: string | null;
+  grantedFor: string | null;
+  permissionsRequestId: string | null;
+  attester: string | null;
+  protocolPath: string | null;
+  recipient: string | null;
+  contextId: string | null;
+  parentId: string | null;
+  permissionsGrantId: string | null;
+  // "indexes" end
 }
 
 export interface MessageStoreTable {

--- a/src/message-store-sql.ts
+++ b/src/message-store-sql.ts
@@ -9,7 +9,7 @@ import {
   MessageStoreOptions,
   MessageSort,
   Pagination,
-  SortOrder
+  SortDirection
 } from '@tbd54566975/dwn-sdk-js';
 import { Kysely } from 'kysely';
 import { Database } from './database.js';
@@ -204,7 +204,7 @@ export class MessageStoreSql implements MessageStore {
     if(pagination?.cursor !== undefined) {
       const messageCid = pagination.cursor;
       query = query.where(({ eb, selectFrom, refTuple }) => {
-        const direction = sortDirection === SortOrder.Ascending ? '>' : '<';
+        const direction = sortDirection === SortDirection.Ascending ? '>' : '<';
 
         // fetches the cursor as a sort property tuple from the database based on the messageCid.
         const cursor = selectFrom('messageStore')
@@ -220,8 +220,8 @@ export class MessageStoreSql implements MessageStore {
 
     // sorting by the provided sort property, the tiebreak is always in ascending order regardless of sort
     query =  query
-      .orderBy(sortProperty, sortDirection === SortOrder.Ascending ? 'asc' : 'desc')
-      .orderBy('messageCid', 'asc');
+      .orderBy(sortProperty, sortDirection === SortDirection.Ascending ? 'asc' : 'desc')
+      .orderBy('messageCid', sortDirection === SortDirection.Ascending ? 'asc' : 'desc');
 
     if (pagination?.limit !== undefined && pagination?.limit > 0) {
       // we query for one additional record to decide if we return a pagination cursor or not.
@@ -324,7 +324,7 @@ export class MessageStoreSql implements MessageStore {
 
   private getOrderBy(
     messageSort?: MessageSort
-  ):{ property: 'dateCreated' | 'datePublished' | 'messageTimestamp', direction: SortOrder } {
+  ):{ property: 'dateCreated' | 'datePublished' | 'messageTimestamp', direction: SortDirection } {
     if(messageSort?.dateCreated !== undefined)  {
       return  { property: 'dateCreated', direction: messageSort.dateCreated };
     } else if(messageSort?.datePublished !== undefined) {
@@ -332,7 +332,7 @@ export class MessageStoreSql implements MessageStore {
     } else if (messageSort?.messageTimestamp !== undefined) {
       return  { property: 'messageTimestamp', direction: messageSort.messageTimestamp };
     } else {
-      return  { property: 'messageTimestamp', direction: SortOrder.Ascending };
+      return  { property: 'messageTimestamp', direction: SortDirection.Ascending };
     }
   }
 }

--- a/src/utils/sanitize.ts
+++ b/src/utils/sanitize.ts
@@ -1,4 +1,6 @@
-export function sanitizeRecords(records: Record<string, string | number>) {
+import { Filter } from '@tbd54566975/dwn-sdk-js';
+
+export function sanitizeIndexes(records: Record<string, string | number | boolean>) {
   for (let key in records) {
     let value = records[key];
     records[key] = sanitizedValue(value);
@@ -13,4 +15,30 @@ export function sanitizedValue(value: any): string | number {
   } else {
     return JSON.stringify(value);
   }
+}
+
+export function sanitizeFilterValue(value: any): any {
+  switch (typeof value) {
+  case 'number':
+  case 'string':
+  case 'object':
+    return  value;
+  default:
+    return JSON.stringify(value);
+  }
+}
+
+export function sanitizeFilters(filters: Filter[]) {
+  for (let key in filters) {
+    let filter = filters[key];
+    filters[key] = sanitizeFilter(filter);
+  }
+}
+
+export function sanitizeFilter(filter: Filter): Filter {
+  for (let key in filter) {
+    let value = filter[key];
+    filter[key] = sanitizeFilterValue(value);
+  }
+  return filter;
 }

--- a/src/utils/sanitize.ts
+++ b/src/utils/sanitize.ts
@@ -7,24 +7,25 @@ export function sanitizeIndexes(records: Record<string, string | number | boolea
   }
 }
 
-export function sanitizedValue(value: any): string | number {
-  if (typeof value === 'string') {
+// we sanitize the incoming value into a string or number
+// sqlite3 and the driver we use does not support booleans, so we convert them to strings
+export function sanitizedValue(value: string | number | boolean): string | number {
+  switch (typeof value) {
+  case 'boolean':
+    return String(value);
+  default:
     return value;
-  } else if (typeof value === 'number') {
-    return value;
-  } else {
-    return JSON.stringify(value);
   }
 }
 
+// we sanitize the filter value for a string representation of the boolean
+// TODO: export filter types from `dwn-sdk-js`
 export function sanitizeFilterValue(value: any): any {
   switch (typeof value) {
-  case 'number':
-  case 'string':
-  case 'object':
-    return  value;
+  case 'boolean':
+    return String(value);
   default:
-    return JSON.stringify(value);
+    return value;
   }
 }
 


### PR DESCRIPTION
- Update `dwn-sdk-js` to `v0.2.9`
- Implement breaking changes from prior build:
  - Add Indexes to `EventLog` implementation.
    - Future PR/work will combine `EventLog` and `MessageStore` into a single index.
  - Add `queryEvents` method to the `EventLog` implementation.
  - `messageCid` tie breaker sorts same direction as sorted value.
- Update index properties and query filter sanitization to account for `sqlite3` lack of `boolean` types.

