### PR TITLE
PaginationCursor update from `dwn-sdk-js`

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@tbd54566975/dwn-sql-store",
-  "version": "0.2.6",
+  "version": "0.2.7",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@tbd54566975/dwn-sql-store",
-      "version": "0.2.6",
+      "version": "0.2.7",
       "license": "Apache-2.0",
       "dependencies": {
         "@ipld/dag-cbor": "^9.0.5",

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "license": "Apache-2.0",
       "dependencies": {
         "@ipld/dag-cbor": "^9.0.5",
-        "@tbd54566975/dwn-sdk-js": "0.2.12",
+        "@tbd54566975/dwn-sdk-js": "0.2.13",
         "kysely": "0.26.3",
         "multiformats": "12.0.1",
         "readable-stream": "4.4.2"
@@ -895,9 +895,9 @@
       "dev": true
     },
     "node_modules/@tbd54566975/dwn-sdk-js": {
-      "version": "0.2.12",
-      "resolved": "https://registry.npmjs.org/@tbd54566975/dwn-sdk-js/-/dwn-sdk-js-0.2.12.tgz",
-      "integrity": "sha512-Y1ENGZcaHyqc+NG+EXFAN7k/zRqJ5JuBr9cbkpupqUuhwN9Xjdej8uuoGviHx/72jhpx9dKfcCBeHztiTMMZOg==",
+      "version": "0.2.13",
+      "resolved": "https://registry.npmjs.org/@tbd54566975/dwn-sdk-js/-/dwn-sdk-js-0.2.13.tgz",
+      "integrity": "sha512-r1B3HVL+BO7A01GQoc7hlRZA7PYykLnKcUjSZCrvR+K8SoFNoo/y+DHcCHFx9u5fvFgjUx5hXl/LW2c7r+SPXw==",
       "dependencies": {
         "@ipld/dag-cbor": "9.0.3",
         "@js-temporal/polyfill": "0.4.4",

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "license": "Apache-2.0",
       "dependencies": {
         "@ipld/dag-cbor": "^9.0.5",
-        "@tbd54566975/dwn-sdk-js": "0.2.10",
+        "@tbd54566975/dwn-sdk-js": "0.2.12",
         "kysely": "0.26.3",
         "multiformats": "12.0.1",
         "readable-stream": "4.4.2"
@@ -895,9 +895,9 @@
       "dev": true
     },
     "node_modules/@tbd54566975/dwn-sdk-js": {
-      "version": "0.2.10",
-      "resolved": "https://registry.npmjs.org/@tbd54566975/dwn-sdk-js/-/dwn-sdk-js-0.2.10.tgz",
-      "integrity": "sha512-CoKO8+NciwWNzD4xRoAAgeElqQCXKM4Fc+zEHsUWD0M3E9v67hRWiTHI6AenUfQv1RSEB2H4GHUeUOHuEV72uw==",
+      "version": "0.2.12",
+      "resolved": "https://registry.npmjs.org/@tbd54566975/dwn-sdk-js/-/dwn-sdk-js-0.2.12.tgz",
+      "integrity": "sha512-Y1ENGZcaHyqc+NG+EXFAN7k/zRqJ5JuBr9cbkpupqUuhwN9Xjdej8uuoGviHx/72jhpx9dKfcCBeHztiTMMZOg==",
       "dependencies": {
         "@ipld/dag-cbor": "9.0.3",
         "@js-temporal/polyfill": "0.4.4",

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
   "react-native": "./dist/esm/src/main.js",
   "dependencies": {
     "@ipld/dag-cbor": "^9.0.5",
-    "@tbd54566975/dwn-sdk-js": "0.2.12",
+    "@tbd54566975/dwn-sdk-js": "0.2.13",
     "kysely": "0.26.3",
     "multiformats": "12.0.1",
     "readable-stream": "4.4.2"

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
   "react-native": "./dist/esm/src/main.js",
   "dependencies": {
     "@ipld/dag-cbor": "^9.0.5",
-    "@tbd54566975/dwn-sdk-js": "0.2.10",
+    "@tbd54566975/dwn-sdk-js": "0.2.12",
     "kysely": "0.26.3",
     "multiformats": "12.0.1",
     "readable-stream": "4.4.2"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tbd54566975/dwn-sql-store",
-  "version": "0.2.6",
+  "version": "0.2.7",
   "description": "SQL backed implementations of DWN MessageStore, DataStore, and EventLog",
   "type": "module",
   "license": "Apache-2.0",

--- a/src/database.ts
+++ b/src/database.ts
@@ -1,7 +1,7 @@
 import type { Generated } from 'kysely';
 
 export interface EventLogTable {
-  id: Generated<number>;
+  watermark: Generated<number>;
   tenant: string;
   messageCid: string;
 

--- a/src/database.ts
+++ b/src/database.ts
@@ -1,7 +1,7 @@
 import type { Generated } from 'kysely';
 
 export interface EventLogTable {
-  watermark: Generated<number>;
+  id: Generated<number>;
   tenant: string;
   messageCid: string;
 

--- a/src/event-log-sql.ts
+++ b/src/event-log-sql.ts
@@ -123,8 +123,12 @@ export class EventLogSql implements EventLog {
     if(cursor !== undefined) {
       const cursorId = cursor.messageCid;
 
-      // eventLog in the sql store uses the id cursor value which is a number
-      const cursorValue = cursor.value as number;
+      // eventLog in the sql store uses the watermark cursor value which is a number in SQL
+      // if not we will return empty results
+      const cursorValue = cursor.value;
+      if (typeof cursorValue  !== 'number') {
+        return { events: [] };
+      }
 
       query = query.where(({ eb, refTuple, tuple }) => {
         // https://kysely-org.github.io/kysely-apidoc/interfaces/ExpressionBuilder.html#refTuple

--- a/src/event-log-sql.ts
+++ b/src/event-log-sql.ts
@@ -120,6 +120,7 @@ export class EventLogSql implements EventLog {
       sanitizeFilters(filters);
       query = filterSelectQuery(filters, query);
     }
+
     if(cursor !== undefined) {
       const cursorId = cursor.messageCid;
 
@@ -139,6 +140,7 @@ export class EventLogSql implements EventLog {
     query = query.orderBy('watermark', 'asc').orderBy('messageCid', 'asc');
 
     const events: string[] = [];
+    // we always return a cursor with the event log query, so we set the return cursor to the properties of the last item.
     let returnCursor: PaginationCursor | undefined;
     if (this.#dialect.isStreamingSupported) {
       for await (let { messageCid, watermark: value } of query.stream()) {

--- a/src/event-log-sql.ts
+++ b/src/event-log-sql.ts
@@ -1,8 +1,9 @@
 import type { Database } from './database.js';
-import type { EventLog, GetEventsOptions, Filter } from '@tbd54566975/dwn-sdk-js';
-import { Kysely } from 'kysely';
+import type { EventLog, Filter, PaginationCursor } from '@tbd54566975/dwn-sdk-js';
+
 import { Dialect } from './dialect/dialect.js';
 import { filterSelectQuery } from './utils/filter.js';
+import { Kysely } from 'kysely';
 import { sanitizeFilters, sanitizeIndexes } from './utils/sanitize.js';
 
 export class EventLogSql implements EventLog {
@@ -56,7 +57,7 @@ export class EventLogSql implements EventLog {
       // "indexes" end
 
     // Add columns that have dialect-specific constraints
-    createTable = this.#dialect.addAutoIncrementingColumn(createTable, 'watermark', (col) => col.primaryKey());
+    createTable = this.#dialect.addAutoIncrementingColumn(createTable, 'id', (col) => col.primaryKey());
 
     await createTable.execute();
   }
@@ -90,18 +91,18 @@ export class EventLogSql implements EventLog {
 
   async getEvents(
     tenant: string,
-    options?: GetEventsOptions
-  ): Promise<string[]> {
+    cursor?: PaginationCursor
+  ): Promise<{events: string[], cursor?: PaginationCursor }> {
 
     // get events is simply a query without any filters. gets all events beyond the cursor.
-    return this.queryEvents(tenant, [], options?.cursor);
+    return this.queryEvents(tenant, [], cursor);
   }
 
   async queryEvents(
     tenant: string,
     filters: Filter[],
-    cursor?: string
-  ): Promise<string[]> {
+    cursor?: PaginationCursor
+  ): Promise<{events: string[], cursor?: PaginationCursor }> {
     if (!this.#db) {
       throw new Error(
         'Connection to database not open. Call `open` before using `queryEvents`.'
@@ -110,6 +111,7 @@ export class EventLogSql implements EventLog {
 
     let query = this.#db
       .selectFrom('eventLog')
+      .select('id')
       .select('messageCid')
       .where('tenant', '=', tenant);
 
@@ -118,37 +120,36 @@ export class EventLogSql implements EventLog {
       sanitizeFilters(filters);
       query = filterSelectQuery(filters, query);
     }
-
     if(cursor !== undefined) {
-      const messageCid = cursor;
-      query = query.where(({ eb, selectFrom }) => {
+      const cursorId = cursor.messageCid;
 
-        // fetch the watermark of the messageCid cursor
-        const cursor = selectFrom('eventLog')
-          .select('watermark')
-          .where('tenant', '=', tenant)
-          .where('messageCid', '=', messageCid)
-          .limit(1);
+      // eventLog in the sql store uses the id cursor value which is a number
+      const cursorValue = cursor.value as number;
 
-        return eb('watermark', '>' , cursor);
+      query = query.where(({ eb, refTuple, tuple }) => {
+        // https://kysely-org.github.io/kysely-apidoc/interfaces/ExpressionBuilder.html#refTuple
+        return eb(refTuple('id', 'messageCid'), '>', tuple(cursorValue, cursorId));
       });
     }
 
-    query = query.orderBy('watermark', 'asc');
+    query = query.orderBy('id', 'asc').orderBy('messageCid', 'asc');
 
     const events: string[] = [];
+    let returnCursor: PaginationCursor | undefined;
     if (this.#dialect.isStreamingSupported) {
-      for await (let { messageCid } of query.stream()) {
+      for await (let { messageCid, id } of query.stream()) {
         events.push(messageCid);
+        returnCursor = { messageCid, value: id };
       }
     } else {
       const results = await query.execute();
-      for (let { messageCid } of results) {
+      for (let { messageCid, id } of results) {
         events.push(messageCid);
+        returnCursor = { messageCid, value: id };
       }
     }
 
-    return events;
+    return { events, cursor: returnCursor };
   }
 
   async deleteEventsByCid(

--- a/src/event-log-sql.ts
+++ b/src/event-log-sql.ts
@@ -122,18 +122,14 @@ export class EventLogSql implements EventLog {
     }
 
     if(cursor !== undefined) {
-      const cursorId = cursor.messageCid;
-
       // eventLog in the sql store uses the watermark cursor value which is a number in SQL
       // if not we will return empty results
-      const cursorValue = cursor.value;
-      if (typeof cursorValue  !== 'number') {
-        return { events: [] };
-      }
+      const cursorValue = cursor.value as number;
+      const cursorMessageCid = cursor.messageCid;
 
       query = query.where(({ eb, refTuple, tuple }) => {
         // https://kysely-org.github.io/kysely-apidoc/interfaces/ExpressionBuilder.html#refTuple
-        return eb(refTuple('watermark', 'messageCid'), '>', tuple(cursorValue, cursorId));
+        return eb(refTuple('watermark', 'messageCid'), '>', tuple(cursorValue, cursorMessageCid));
       });
     }
 

--- a/src/message-store-sql.ts
+++ b/src/message-store-sql.ts
@@ -201,7 +201,7 @@ export class MessageStoreSql implements MessageStore {
 
     if(pagination?.cursor !== undefined) {
       const cursorId = pagination.cursor.messageCid;
-      // we only allow sorting by string values currently in MessageSort (dates/timestamps)
+      // currently the sort property is explicitly either `dateCreated` | `messageTimestamp` | `datePublished` which are all strings
       const cursorValue = pagination.cursor.value as string;
 
       query = query.where(({ eb, refTuple, tuple }) => {

--- a/src/message-store-sql.ts
+++ b/src/message-store-sql.ts
@@ -201,7 +201,6 @@ export class MessageStoreSql implements MessageStore {
 
     if(pagination?.cursor !== undefined) {
       // currently the sort property is explicitly either `dateCreated` | `messageTimestamp` | `datePublished` which are all strings
-      // if it is not of type string we return an empty result set
       const cursorValue = pagination.cursor.value as string;
       const cursorMessageId = pagination.cursor.messageCid;
 

--- a/src/message-store-sql.ts
+++ b/src/message-store-sql.ts
@@ -202,7 +202,11 @@ export class MessageStoreSql implements MessageStore {
     if(pagination?.cursor !== undefined) {
       const cursorId = pagination.cursor.messageCid;
       // currently the sort property is explicitly either `dateCreated` | `messageTimestamp` | `datePublished` which are all strings
-      const cursorValue = pagination.cursor.value as string;
+      // if it is not of type string we return an empty result set
+      const cursorValue = pagination.cursor.value;
+      if (typeof cursorValue !== 'string') {
+        return { messages: [] };
+      }
 
       query = query.where(({ eb, refTuple, tuple }) => {
         const direction = sortDirection === SortDirection.Ascending ? '>' : '<';

--- a/src/message-store-sql.ts
+++ b/src/message-store-sql.ts
@@ -201,6 +201,7 @@ export class MessageStoreSql implements MessageStore {
 
     if(pagination?.cursor !== undefined) {
       // currently the sort property is explicitly either `dateCreated` | `messageTimestamp` | `datePublished` which are all strings
+      // TODO: https://github.com/TBD54566975/dwn-sdk-js/issues/664 to handle the edge case
       const cursorValue = pagination.cursor.value as string;
       const cursorMessageId = pagination.cursor.messageCid;
 

--- a/src/message-store-sql.ts
+++ b/src/message-store-sql.ts
@@ -200,18 +200,15 @@ export class MessageStoreSql implements MessageStore {
     const { property: sortProperty, direction: sortDirection } = this.extractSortProperties(messageSort);
 
     if(pagination?.cursor !== undefined) {
-      const cursorId = pagination.cursor.messageCid;
       // currently the sort property is explicitly either `dateCreated` | `messageTimestamp` | `datePublished` which are all strings
       // if it is not of type string we return an empty result set
-      const cursorValue = pagination.cursor.value;
-      if (typeof cursorValue !== 'string') {
-        return { messages: [] };
-      }
+      const cursorValue = pagination.cursor.value as string;
+      const cursorMessageId = pagination.cursor.messageCid;
 
       query = query.where(({ eb, refTuple, tuple }) => {
         const direction = sortDirection === SortDirection.Ascending ? '>' : '<';
         // https://kysely-org.github.io/kysely-apidoc/interfaces/ExpressionBuilder.html#refTuple
-        return eb(refTuple(sortProperty, 'messageCid'), direction, tuple(cursorValue, cursorId));
+        return eb(refTuple(sortProperty, 'messageCid'), direction, tuple(cursorValue, cursorMessageId));
       });
     }
 


### PR DESCRIPTION
`PaginationCursor` is a new object in `dwn-sdk-js`.

It is comprised of a `messageCid` and a `value`. The `value` is of the sort property that you would like to continue your pagination from. The `messageCid` is used as a tiebreaker in the same way that query pagination already does.