### PR TITLE
release version to 0.3.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@tbd54566975/dwn-sql-store",
-  "version": "0.2.14",
+  "version": "0.3.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@tbd54566975/dwn-sql-store",
-      "version": "0.2.14",
+      "version": "0.3.0",
       "license": "Apache-2.0",
       "dependencies": {
         "@ipld/dag-cbor": "^9.0.5",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tbd54566975/dwn-sql-store",
-  "version": "0.2.14",
+  "version": "0.3.0",
   "description": "SQL backed implementations of DWN MessageStore, DataStore, and EventLog",
   "type": "module",
   "license": "Apache-2.0",


### PR DESCRIPTION
- Change table name from `messageStore` to `messageStoreMessages`
- Change table name from `eventLog` to `eventLogMessages`
- Adds support for `tag` indexing