### PR TITLE
Fixed bug where `number` type is too small for unix epoch in some SQL variants

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,9 @@ SQL backed implementations of DWN `MessageStore`, `DataStore`, and `EventLog`.
 * MySQL ✔️
 * PostgreSQL ✔️
 
+> NOTE:
+See [SQL Dialect Variations](sql-dialect-variations) for the list of special handling to support the above SQL variations.
+
 # Installation
 
 ```bash
@@ -171,3 +174,5 @@ Docker is used to spin up a local containerized DBs for testing purposes. Docker
 | `npm run test-coverage` | runs tests and includes coverage            |
 | `npm run lint`          | runs linter                                 |
 | `npm run lint:fix`      | runs linter and fixes auto-fixable problems |
+
+[codeowners-link]: https://github.com/TBD54566975/web5-js/blob/main/sql-dialect-variations.md

--- a/sql-dialect-variations.md
+++ b/sql-dialect-variations.md
@@ -1,0 +1,19 @@
+# SQL Dialect Variations
+
+We use `Kysely` to help us abstract differences between SQL variants in this codebase. Unfortunately many differences are not fully abstracted away. This document outlines the specific handling required in this codebase to support variations between MySQL, PostgreSQL, and SQLite. Its purpose is to help future repository maintainers avoid known pitfalls. Note that this may not be an exhaustive list of all special handling within the codebase.
+
+## MySQL
+
+- Does not support adding a reference column directly, requires adding a foreign key constraint instead.
+
+- When inserting values into a table, the inserted values are returned by default, unlike PostgreSQL and SQLite.
+
+
+## PostgreSQL
+
+- Uses a special type: `serial` for auto-increment columns.
+
+- Uses a special type: `bytea` for blob columns.
+
+- `bigint` column type gets returned as `string` in `pg` library.
+

--- a/tests/test-suite.spec.ts
+++ b/tests/test-suite.spec.ts
@@ -17,7 +17,7 @@ describe('SQL Store Test Suite', () => {
       messageStore       : new MessageStoreSql(testMysqlDialect),
       dataStore          : new DataStoreSql(testMysqlDialect),
       eventLog           : new EventLogSql(testMysqlDialect),
-      resumableTaskStore : new ResumableTaskStoreSql(testSqliteDialect),
+      resumableTaskStore : new ResumableTaskStoreSql(testMysqlDialect),
     });
   });
 
@@ -26,7 +26,7 @@ describe('SQL Store Test Suite', () => {
       messageStore       : new MessageStoreSql(testPostgresDialect),
       dataStore          : new DataStoreSql(testPostgresDialect),
       eventLog           : new EventLogSql(testPostgresDialect),
-      resumableTaskStore : new ResumableTaskStoreSql(testSqliteDialect),
+      resumableTaskStore : new ResumableTaskStoreSql(testPostgresDialect),
     });
   });
 


### PR DESCRIPTION
- Fixed bug where `number` type is too small for unix epoch in some SQL variants
- Fixed bug where only SQLite was tested against `dwn-sdk-js` test suite for `ReumsableTaskStore` (the reason why the bug was not caught)
- Special handling for PostgreSQL on `bigint`
