### PR TITLE
Upgrade `dwn-sdk-js`

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,16 +1,16 @@
 {
   "name": "@tbd54566975/dwn-sql-store",
-  "version": "0.6.6",
+  "version": "0.6.7",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@tbd54566975/dwn-sql-store",
-      "version": "0.6.6",
+      "version": "0.6.7",
       "license": "Apache-2.0",
       "dependencies": {
         "@ipld/dag-cbor": "9.0.5",
-        "@tbd54566975/dwn-sdk-js": "0.4.6",
+        "@tbd54566975/dwn-sdk-js": "0.4.7",
         "kysely": "0.26.3",
         "multiformats": "12.0.1",
         "readable-stream": "4.4.2"
@@ -39,8 +39,7 @@
         "pg": "8.11.1",
         "pg-cursor": "2.10.1",
         "rimraf": "5.0.1",
-        "sinon": "13.0.1",
-        "ts-sinon": "2.0.2",
+        "sinon": "^18.0.1",
         "typescript": "5.0.4"
       },
       "engines": {
@@ -873,44 +872,53 @@
       }
     },
     "node_modules/@sinonjs/commons": {
-      "version": "1.8.6",
-      "resolved": "https://registry.npmjs.org/@sinonjs/commons/-/commons-1.8.6.tgz",
-      "integrity": "sha512-Ky+XkAkqPZSm3NLBeUng77EBQl3cmeJhITaGHdYH8kjVB+aun3S4XBRti2zt17mtt0mIUDiNxYeoJm6drVvBJQ==",
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/@sinonjs/commons/-/commons-3.0.1.tgz",
+      "integrity": "sha512-K3mCHKQ9sVh8o1C9cxkwxaOmXoAMlDxC1mYyHrjqOWEcBjYr76t96zL2zlj5dUGZ3HSw240X1qgH3Mjf1yJWpQ==",
       "dev": true,
       "dependencies": {
         "type-detect": "4.0.8"
       }
     },
     "node_modules/@sinonjs/fake-timers": {
-      "version": "9.1.2",
-      "resolved": "https://registry.npmjs.org/@sinonjs/fake-timers/-/fake-timers-9.1.2.tgz",
-      "integrity": "sha512-BPS4ynJW/o92PUR4wgriz2Ud5gpST5vz6GQfMixEDK0Z8ZCUv2M7SkBLykH56T++Xs+8ln9zTGbOvNGIe02/jw==",
+      "version": "11.2.2",
+      "resolved": "https://registry.npmjs.org/@sinonjs/fake-timers/-/fake-timers-11.2.2.tgz",
+      "integrity": "sha512-G2piCSxQ7oWOxwGSAyFHfPIsyeJGXYtc6mFbnFA+kRXkiEnTl8c/8jul2S329iFBnDI9HGoeWWAZvuvOkZccgw==",
       "dev": true,
       "dependencies": {
-        "@sinonjs/commons": "^1.7.0"
+        "@sinonjs/commons": "^3.0.0"
       }
     },
     "node_modules/@sinonjs/samsam": {
-      "version": "6.1.3",
-      "resolved": "https://registry.npmjs.org/@sinonjs/samsam/-/samsam-6.1.3.tgz",
-      "integrity": "sha512-nhOb2dWPeb1sd3IQXL/dVPnKHDOAFfvichtBf4xV00/rU1QbPCQqKMbvIheIjqwVjh7qIgf2AHTHi391yMOMpQ==",
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/@sinonjs/samsam/-/samsam-8.0.0.tgz",
+      "integrity": "sha512-Bp8KUVlLp8ibJZrnvq2foVhP0IVX2CIprMJPK0vqGqgrDa0OHVKeZyBykqskkrdxV6yKBPmGasO8LVjAKR3Gew==",
       "dev": true,
       "dependencies": {
-        "@sinonjs/commons": "^1.6.0",
+        "@sinonjs/commons": "^2.0.0",
         "lodash.get": "^4.4.2",
         "type-detect": "^4.0.8"
       }
     },
+    "node_modules/@sinonjs/samsam/node_modules/@sinonjs/commons": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@sinonjs/commons/-/commons-2.0.0.tgz",
+      "integrity": "sha512-uLa0j859mMrg2slwQYdO/AkrOfmH+X6LTVmNTS9CqexuE2IvVORIkSpJLqePAbEnKJ77aMmCwr1NUZ57120Xcg==",
+      "dev": true,
+      "dependencies": {
+        "type-detect": "4.0.8"
+      }
+    },
     "node_modules/@sinonjs/text-encoding": {
-      "version": "0.7.2",
-      "resolved": "https://registry.npmjs.org/@sinonjs/text-encoding/-/text-encoding-0.7.2.tgz",
-      "integrity": "sha512-sXXKG+uL9IrKqViTtao2Ws6dy0znu9sOaP1di/jKGW1M6VssO8vlpXCQcpZ+jisQ1tTFAC5Jo/EOzFbggBagFQ==",
+      "version": "0.7.3",
+      "resolved": "https://registry.npmjs.org/@sinonjs/text-encoding/-/text-encoding-0.7.3.tgz",
+      "integrity": "sha512-DE427ROAphMQzU4ENbliGYrBSYPXF+TtLg9S8vzeA+OF4ZKzoDdzfL8sxuMUGS/lgRhM6j1URSk9ghf7Xo1tyA==",
       "dev": true
     },
     "node_modules/@tbd54566975/dwn-sdk-js": {
-      "version": "0.4.6",
-      "resolved": "https://registry.npmjs.org/@tbd54566975/dwn-sdk-js/-/dwn-sdk-js-0.4.6.tgz",
-      "integrity": "sha512-eTd9v2ioT+hYrmob28OgxyLgOPAqJosb8rIAHDpFzEjYlQZSxCEohIZysMrLgWIcSLljyViSFr06mDelRPgGPg==",
+      "version": "0.4.7",
+      "resolved": "https://registry.npmjs.org/@tbd54566975/dwn-sdk-js/-/dwn-sdk-js-0.4.7.tgz",
+      "integrity": "sha512-VYaLT4FKdHfVvUPZbicUpF77erkOSi1xBP/EVQIpnp0khPujp2lYcojbRcw4c4JR23CrRvLPy/iWXmEhdP8LqA==",
       "dependencies": {
         "@ipld/dag-cbor": "9.0.3",
         "@js-temporal/polyfill": "0.4.4",
@@ -1217,31 +1225,6 @@
         "@types/node": "*",
         "@types/send": "*"
       }
-    },
-    "node_modules/@types/sinon": {
-      "version": "9.0.11",
-      "resolved": "https://registry.npmjs.org/@types/sinon/-/sinon-9.0.11.tgz",
-      "integrity": "sha512-PwP4UY33SeeVKodNE37ZlOsR9cReypbMJOhZ7BVE0lB+Hix3efCOxiJWiE5Ia+yL9Cn2Ch72EjFTRze8RZsNtg==",
-      "dev": true,
-      "dependencies": {
-        "@types/sinonjs__fake-timers": "*"
-      }
-    },
-    "node_modules/@types/sinon-chai": {
-      "version": "3.2.12",
-      "resolved": "https://registry.npmjs.org/@types/sinon-chai/-/sinon-chai-3.2.12.tgz",
-      "integrity": "sha512-9y0Gflk3b0+NhQZ/oxGtaAJDvRywCa5sIyaVnounqLvmf93yBF4EgIRspePtkMs3Tr844nCclYMlcCNmLCvjuQ==",
-      "dev": true,
-      "dependencies": {
-        "@types/chai": "*",
-        "@types/sinon": "*"
-      }
-    },
-    "node_modules/@types/sinonjs__fake-timers": {
-      "version": "8.1.5",
-      "resolved": "https://registry.npmjs.org/@types/sinonjs__fake-timers/-/sinonjs__fake-timers-8.1.5.tgz",
-      "integrity": "sha512-mQkU2jY8jJEF7YHjHvsQO8+3ughTL1mcnn96igfhONmR+fUPSKIkefQYpSe8bsly2Ep7oQbn/6VG5/9/0qcArQ==",
-      "dev": true
     },
     "node_modules/@types/superagent": {
       "version": "8.1.7",
@@ -3319,12 +3302,6 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
-    "node_modules/isarray": {
-      "version": "0.0.1",
-      "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
-      "integrity": "sha512-D2S+3GLxWH+uhrNEcoh/fnmYeP8E8/zHl644d/jdA0g2uyXvy3sb0qxotE+ne0LtccHknQzWwZEzhak7oJ0COQ==",
-      "dev": true
-    },
     "node_modules/isexe": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
@@ -3970,34 +3947,16 @@
       "dev": true
     },
     "node_modules/nise": {
-      "version": "5.1.9",
-      "resolved": "https://registry.npmjs.org/nise/-/nise-5.1.9.tgz",
-      "integrity": "sha512-qOnoujW4SV6e40dYxJOb3uvuoPHtmLzIk4TFo+j0jPJoC+5Z9xja5qH5JZobEPsa8+YYphMrOSwnrshEhG2qww==",
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/nise/-/nise-6.0.1.tgz",
+      "integrity": "sha512-DAyWGPQEuJVlL2eqKw6gdZKT+E/jo/ZrjEUDAslJLluCz81nWy+KSYybNp3KFm887Yvp7hv12jSM82ld8BmLxg==",
       "dev": true,
       "dependencies": {
         "@sinonjs/commons": "^3.0.0",
         "@sinonjs/fake-timers": "^11.2.2",
         "@sinonjs/text-encoding": "^0.7.2",
         "just-extend": "^6.2.0",
-        "path-to-regexp": "^6.2.1"
-      }
-    },
-    "node_modules/nise/node_modules/@sinonjs/commons": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/@sinonjs/commons/-/commons-3.0.1.tgz",
-      "integrity": "sha512-K3mCHKQ9sVh8o1C9cxkwxaOmXoAMlDxC1mYyHrjqOWEcBjYr76t96zL2zlj5dUGZ3HSw240X1qgH3Mjf1yJWpQ==",
-      "dev": true,
-      "dependencies": {
-        "type-detect": "4.0.8"
-      }
-    },
-    "node_modules/nise/node_modules/@sinonjs/fake-timers": {
-      "version": "11.2.2",
-      "resolved": "https://registry.npmjs.org/@sinonjs/fake-timers/-/fake-timers-11.2.2.tgz",
-      "integrity": "sha512-G2piCSxQ7oWOxwGSAyFHfPIsyeJGXYtc6mFbnFA+kRXkiEnTl8c/8jul2S329iFBnDI9HGoeWWAZvuvOkZccgw==",
-      "dev": true,
-      "dependencies": {
-        "@sinonjs/commons": "^3.0.0"
+        "path-to-regexp": "^8.1.0"
       }
     },
     "node_modules/node-abi": {
@@ -4220,10 +4179,13 @@
       }
     },
     "node_modules/path-to-regexp": {
-      "version": "6.2.2",
-      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-6.2.2.tgz",
-      "integrity": "sha512-GQX3SSMokngb36+whdpRXE+3f9V8UzyAorlYvOGx87ufGHehNTn5lCxrKtLyZ4Yl/wEKnNnr98ZzOwwDZV5ogw==",
-      "dev": true
+      "version": "8.1.0",
+      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-8.1.0.tgz",
+      "integrity": "sha512-Bqn3vc8CMHty6zuD+tG23s6v2kwxslHEhTj4eYaVKGIEB+YX/2wd0/rgXLFD9G9id9KCtbVy/3ZgmvZjpa0UdQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=16"
+      }
     },
     "node_modules/path-type": {
       "version": "4.0.0",
@@ -4950,22 +4912,30 @@
       }
     },
     "node_modules/sinon": {
-      "version": "13.0.1",
-      "resolved": "https://registry.npmjs.org/sinon/-/sinon-13.0.1.tgz",
-      "integrity": "sha512-8yx2wIvkBjIq/MGY1D9h1LMraYW+z1X0mb648KZnKSdvLasvDu7maa0dFaNYdTDczFgbjNw2tOmWdTk9saVfwQ==",
-      "deprecated": "16.1.1",
+      "version": "18.0.1",
+      "resolved": "https://registry.npmjs.org/sinon/-/sinon-18.0.1.tgz",
+      "integrity": "sha512-a2N2TDY1uGviajJ6r4D1CyRAkzE9NNVlYOV1wX5xQDuAk0ONgzgRl0EjCQuRCPxOwp13ghsMwt9Gdldujs39qw==",
       "dev": true,
       "dependencies": {
-        "@sinonjs/commons": "^1.8.3",
-        "@sinonjs/fake-timers": "^9.0.0",
-        "@sinonjs/samsam": "^6.1.1",
-        "diff": "^5.0.0",
-        "nise": "^5.1.1",
-        "supports-color": "^7.2.0"
+        "@sinonjs/commons": "^3.0.1",
+        "@sinonjs/fake-timers": "11.2.2",
+        "@sinonjs/samsam": "^8.0.0",
+        "diff": "^5.2.0",
+        "nise": "^6.0.0",
+        "supports-color": "^7"
       },
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/sinon"
+      }
+    },
+    "node_modules/sinon/node_modules/diff": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/diff/-/diff-5.2.0.tgz",
+      "integrity": "sha512-uIFDxqpRZGZ6ThOk84hEfqWoHx2devRFvpTZcTHur85vImfaxUbTW9Ryh4CpCuDnToOP1CEtXKIgytHBPVff5A==",
+      "dev": true,
+      "engines": {
+        "node": ">=0.3.1"
       }
     },
     "node_modules/slash": {
@@ -5218,100 +5188,6 @@
       "version": "0.0.3",
       "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
       "integrity": "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw=="
-    },
-    "node_modules/ts-sinon": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/ts-sinon/-/ts-sinon-2.0.2.tgz",
-      "integrity": "sha512-Eh6rXPQruACHPn+/e5HsIMaHZa17tGP/scGjUeW5eJ/Levn8hBV6zSP/6QkEDUP7wLkTyY0yeYikjpTzgC9Gew==",
-      "dev": true,
-      "dependencies": {
-        "@types/node": "^14.6.1",
-        "@types/sinon": "^9.0.5",
-        "@types/sinon-chai": "^3.2.4",
-        "sinon": "^9.0.3"
-      }
-    },
-    "node_modules/ts-sinon/node_modules/@sinonjs/fake-timers": {
-      "version": "6.0.1",
-      "resolved": "https://registry.npmjs.org/@sinonjs/fake-timers/-/fake-timers-6.0.1.tgz",
-      "integrity": "sha512-MZPUxrmFubI36XS1DI3qmI0YdN1gks62JtFZvxR67ljjSNCeK6U08Zx4msEWOXuofgqUt6zPHSi1H9fbjR/NRA==",
-      "dev": true,
-      "dependencies": {
-        "@sinonjs/commons": "^1.7.0"
-      }
-    },
-    "node_modules/ts-sinon/node_modules/@sinonjs/samsam": {
-      "version": "5.3.1",
-      "resolved": "https://registry.npmjs.org/@sinonjs/samsam/-/samsam-5.3.1.tgz",
-      "integrity": "sha512-1Hc0b1TtyfBu8ixF/tpfSHTVWKwCBLY4QJbkgnE7HcwyvT2xArDxb4K7dMgqRm3szI+LJbzmW/s4xxEhv6hwDg==",
-      "dev": true,
-      "dependencies": {
-        "@sinonjs/commons": "^1.6.0",
-        "lodash.get": "^4.4.2",
-        "type-detect": "^4.0.8"
-      }
-    },
-    "node_modules/ts-sinon/node_modules/@types/node": {
-      "version": "14.18.63",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-14.18.63.tgz",
-      "integrity": "sha512-fAtCfv4jJg+ExtXhvCkCqUKZ+4ok/JQk01qDKhL5BDDoS3AxKXhV5/MAVUZyQnSEd2GT92fkgZl0pz0Q0AzcIQ==",
-      "dev": true
-    },
-    "node_modules/ts-sinon/node_modules/diff": {
-      "version": "4.0.2",
-      "resolved": "https://registry.npmjs.org/diff/-/diff-4.0.2.tgz",
-      "integrity": "sha512-58lmxKSA4BNyLz+HHMUzlOEpg09FV+ev6ZMe3vJihgdxzgcwZ8VoEEPmALCZG9LmqfVoNMMKpttIYTVG6uDY7A==",
-      "dev": true,
-      "engines": {
-        "node": ">=0.3.1"
-      }
-    },
-    "node_modules/ts-sinon/node_modules/just-extend": {
-      "version": "4.2.1",
-      "resolved": "https://registry.npmjs.org/just-extend/-/just-extend-4.2.1.tgz",
-      "integrity": "sha512-g3UB796vUFIY90VIv/WX3L2c8CS2MdWUww3CNrYmqza1Fg0DURc2K/O4YrnklBdQarSJ/y8JnJYDGc+1iumQjg==",
-      "dev": true
-    },
-    "node_modules/ts-sinon/node_modules/nise": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/nise/-/nise-4.1.0.tgz",
-      "integrity": "sha512-eQMEmGN/8arp0xsvGoQ+B1qvSkR73B1nWSCh7nOt5neMCtwcQVYQGdzQMhcNscktTsWB54xnlSQFzOAPJD8nXA==",
-      "dev": true,
-      "dependencies": {
-        "@sinonjs/commons": "^1.7.0",
-        "@sinonjs/fake-timers": "^6.0.0",
-        "@sinonjs/text-encoding": "^0.7.1",
-        "just-extend": "^4.0.2",
-        "path-to-regexp": "^1.7.0"
-      }
-    },
-    "node_modules/ts-sinon/node_modules/path-to-regexp": {
-      "version": "1.8.0",
-      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-1.8.0.tgz",
-      "integrity": "sha512-n43JRhlUKUAlibEJhPeir1ncUID16QnEjNpwzNdO3Lm4ywrBpBZ5oLD0I6br9evr1Y9JTqwRtAh7JLoOzAQdVA==",
-      "dev": true,
-      "dependencies": {
-        "isarray": "0.0.1"
-      }
-    },
-    "node_modules/ts-sinon/node_modules/sinon": {
-      "version": "9.2.4",
-      "resolved": "https://registry.npmjs.org/sinon/-/sinon-9.2.4.tgz",
-      "integrity": "sha512-zljcULZQsJxVra28qIAL6ow1Z9tpattkCTEJR4RBP3TGc00FcttsP5pK284Nas5WjMZU5Yzy3kAIp3B3KRf5Yg==",
-      "deprecated": "16.1.1",
-      "dev": true,
-      "dependencies": {
-        "@sinonjs/commons": "^1.8.1",
-        "@sinonjs/fake-timers": "^6.0.1",
-        "@sinonjs/samsam": "^5.3.1",
-        "diff": "^4.0.2",
-        "nise": "^4.0.4",
-        "supports-color": "^7.1.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/sinon"
-      }
     },
     "node_modules/tslib": {
       "version": "2.6.3",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tbd54566975/dwn-sql-store",
-  "version": "0.6.6",
+  "version": "0.6.7",
   "description": "SQL backed implementations of DWN MessageStore, DataStore, and EventLog",
   "type": "module",
   "license": "Apache-2.0",
@@ -21,7 +21,7 @@
   "react-native": "./dist/esm/src/main.js",
   "dependencies": {
     "@ipld/dag-cbor": "9.0.5",
-    "@tbd54566975/dwn-sdk-js": "0.4.6",
+    "@tbd54566975/dwn-sdk-js": "0.4.7",
     "kysely": "0.26.3",
     "multiformats": "12.0.1",
     "readable-stream": "4.4.2"
@@ -50,8 +50,7 @@
     "pg": "8.11.1",
     "pg-cursor": "2.10.1",
     "rimraf": "5.0.1",
-    "sinon": "13.0.1",
-    "ts-sinon": "2.0.2",
+    "sinon": "^18.0.1",
     "typescript": "5.0.4"
   },
   "scripts": {


### PR DESCRIPTION
- upgrades `dwn-sdk-js` to `v0.4.7`
- updates `sinon` to latest version to avoid vuln
- removes unused `sinon-ts` package that has a vuln
- release version `0.6.7` of this package.